### PR TITLE
fix: update drizzle-orm and consolidate CI env setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,10 @@ jobs:
 
     - name: Setup test environment
       run: |
-        echo "DATABASE_URL=postgresql://todo_user:todo_password@localhost:5432/todo_db" > .env.local
-
-    - name: Setup test environment for local DB
-      run: |
-        echo "USE_LOCAL_DB=true" >> .env.local
+        cat <<'EOF' > .env.local
+        DATABASE_URL=postgresql://todo_user:todo_password@localhost:5432/todo_db
+        USE_LOCAL_DB=true
+        EOF
 
     - name: Run database migrations
       run: npm run db:migrate

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@trpc/server": "^10.45.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "drizzle-orm": "^0.33.0",
+        "drizzle-orm": "^0.44.5",
         "lucide-react": "^0.542.0",
         "next": "^14.2.5",
         "postgres": "^3.4.4",
@@ -4330,36 +4330,37 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.33.0.tgz",
-      "integrity": "sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==",
+      "version": "0.44.5",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.5.tgz",
+      "integrity": "sha512-jBe37K7d8ZSKptdKfakQFdeljtu3P2Cbo7tJoJSVZADzIKOBo9IAJPOmMsH2bZl90bZgh8FQlD8BjxXA/zuBkQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=3",
-        "@electric-sql/pglite": ">=0.1.1",
-        "@libsql/client": "*",
-        "@neondatabase/serverless": ">=0.1",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1",
+        "@planetscale/database": ">=1.13",
         "@prisma/client": "*",
         "@tidbcloud/serverless": "*",
         "@types/better-sqlite3": "*",
         "@types/pg": "*",
-        "@types/react": ">=18",
         "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
         "@vercel/postgres": ">=0.8.0",
         "@xata.io/client": "*",
         "better-sqlite3": ">=7",
         "bun-types": "*",
-        "expo-sqlite": ">=13.2.0",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
         "knex": "*",
         "kysely": "*",
         "mysql2": ">=2",
         "pg": ">=8",
         "postgres": ">=3",
-        "react": ">=18",
         "sql.js": ">=1",
         "sqlite3": ">=5"
       },
@@ -4374,6 +4375,9 @@
           "optional": true
         },
         "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
           "optional": true
         },
         "@neondatabase/serverless": {
@@ -4400,10 +4404,10 @@
         "@types/pg": {
           "optional": true
         },
-        "@types/react": {
+        "@types/sql.js": {
           "optional": true
         },
-        "@types/sql.js": {
+        "@upstash/redis": {
           "optional": true
         },
         "@vercel/postgres": {
@@ -4419,6 +4423,9 @@
           "optional": true
         },
         "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
           "optional": true
         },
         "knex": {
@@ -4437,9 +4444,6 @@
           "optional": true
         },
         "prisma": {
-          "optional": true
-        },
-        "react": {
           "optional": true
         },
         "sql.js": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@trpc/server": "^10.45.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "drizzle-orm": "^0.33.0",
+    "drizzle-orm": "^0.44.5",
     "lucide-react": "^0.542.0",
     "next": "^14.2.5",
     "postgres": "^3.4.4",


### PR DESCRIPTION
## Summary
- update drizzle-orm to satisfy drizzle-kit requirements
- write DATABASE_URL and USE_LOCAL_DB to `.env.local` in a single CI step

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run db:migrate` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fd30d180832aa3114b7b8b577a14