### PR TITLE
Add todo service layer and update router to use it

### DIFF
--- a/src/__tests__/server/todo-router.test.ts
+++ b/src/__tests__/server/todo-router.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createCallerFactory } from '@trpc/server';
 import { todoRouter } from '@/server/api/routers/todo';
-import { todoRepository } from '@/server/repositories/todoRepository';
+import { todoService } from '@/server/services/todoService';
 
-vi.mock('@/server/repositories/todoRepository', () => ({
-  todoRepository: {
+vi.mock('@/server/services/todoService', () => ({
+  todoService: {
     getAll: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -23,42 +23,42 @@ describe('Todo Router', () => {
 
   it('should return todos', async () => {
     const todos = [{ id: 1 }];
-    (todoRepository.getAll as any).mockResolvedValue(todos);
+    (todoService.getAll as any).mockResolvedValue(todos);
     const result = await caller.getAll();
-    expect(todoRepository.getAll).toHaveBeenCalled();
+    expect(todoService.getAll).toHaveBeenCalled();
     expect(result).toEqual(todos);
   });
 
   it('should create todo', async () => {
     const input = { title: 'Test', due_date: null };
     const newTodo = { id: 1, ...input };
-    (todoRepository.create as any).mockResolvedValue(newTodo);
+    (todoService.create as any).mockResolvedValue(newTodo);
     const result = await caller.create(input);
-    expect(todoRepository.create).toHaveBeenCalledWith(input);
+    expect(todoService.create).toHaveBeenCalledWith(input);
     expect(result).toEqual(newTodo);
   });
 
   it('should update todo', async () => {
     const input = { id: 1, title: 'Updated', due_date: null };
     const updated = { ...input };
-    (todoRepository.update as any).mockResolvedValue(updated);
+    (todoService.update as any).mockResolvedValue(updated);
     const result = await caller.update(input);
-    expect(todoRepository.update).toHaveBeenCalledWith(input);
+    expect(todoService.update).toHaveBeenCalledWith(input);
     expect(result).toEqual(updated);
   });
 
   it('should delete todo', async () => {
-    (todoRepository.delete as any).mockResolvedValue({ success: true });
+    (todoService.delete as any).mockResolvedValue({ success: true });
     const result = await caller.delete({ id: 1 });
-    expect(todoRepository.delete).toHaveBeenCalledWith(1);
+    expect(todoService.delete).toHaveBeenCalledWith(1);
     expect(result).toEqual({ success: true });
   });
 
   it('should toggle todo', async () => {
     const toggled = { id: 1, done_flag: true };
-    (todoRepository.toggle as any).mockResolvedValue(toggled);
+    (todoService.toggle as any).mockResolvedValue(toggled);
     const result = await caller.toggle({ id: 1 });
-    expect(todoRepository.toggle).toHaveBeenCalledWith(1);
+    expect(todoService.toggle).toHaveBeenCalledWith(1);
     expect(result).toEqual(toggled);
   });
 });

--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -1,33 +1,33 @@
 import { createTRPCRouter, publicProcedure } from '../trpc';
-import { todoRepository } from '@/server/repositories/todoRepository';
+import { todoService } from '@/server/services/todoService';
 import { createTodoSchema, updateTodoSchema, deleteTodoSchema, toggleTodoSchema } from '@/lib/validations';
 
 export const todoRouter = createTRPCRouter({
   getAll: publicProcedure.query(async () => {
-    return await todoRepository.getAll();
+    return await todoService.getAll();
   }),
 
   create: publicProcedure
     .input(createTodoSchema)
     .mutation(async ({ input }) => {
-      return await todoRepository.create(input);
+      return await todoService.create(input);
     }),
 
   update: publicProcedure
     .input(updateTodoSchema)
     .mutation(async ({ input }) => {
-      return await todoRepository.update(input);
+      return await todoService.update(input);
     }),
 
   delete: publicProcedure
     .input(deleteTodoSchema)
     .mutation(async ({ input }) => {
-      return await todoRepository.delete(input.id);
+      return await todoService.delete(input.id);
     }),
 
   toggle: publicProcedure
     .input(toggleTodoSchema)
     .mutation(async ({ input }) => {
-      return await todoRepository.toggle(input.id);
+      return await todoService.toggle(input.id);
     }),
 });

--- a/src/server/services/todoService.ts
+++ b/src/server/services/todoService.ts
@@ -1,0 +1,13 @@
+import { todoRepository } from '@/server/repositories/todoRepository';
+
+export const todoService = {
+  getAll: async () => todoRepository.getAll(),
+  create: async (input: { title: string; due_date?: string | null }) =>
+    todoRepository.create(input),
+  update: async (input: { id: number; title?: string; due_date?: string | null }) =>
+    todoRepository.update(input),
+  delete: async (id: number) => todoRepository.delete(id),
+  toggle: async (id: number) => todoRepository.toggle(id),
+};
+
+export type TodoService = typeof todoService;


### PR DESCRIPTION
## Summary
- add todoService wrapper around repository
- route todo API through service layer
- adjust todo router tests to mock service

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b76956b3e8832a80fdb5c7ea01c2fb