### PR TITLE
feat: client-side column filters with select-all/unselect-all

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,11 @@
+# Design
+
+## Table Filtering
+- Uses TanStack Table `columnFilters` state with a custom filter function that matches rows when the cell value exists in the selected list.
+- Unique values for each column are derived from loaded TODO data.
+- Checkboxes are rendered for each unique value with "全選択" and "全解除" buttons to quickly toggle all options.
+- Filter panels are displayed above the table for visibility.
+
+## Pagination and Sorting
+- TanStack Table's client-side pagination and sorting are retained.
+- Filters operate in conjunction with pagination and sorting.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,7 @@
+# Requirements
+
+- Display TODO list with client-side pagination, sorting, and column filtering.
+- Column filters show all possible values as checkboxes allowing multiple selections.
+- Provide "全選択" (check all) and "全解除" (uncheck all) controls for each column filter.
+- Filters are rendered above the table for quick access.
+- Filtering, sorting, and pagination operate entirely on the client without server calls.


### PR DESCRIPTION
## Summary
- add checkbox-based column filters with select-all and clear-all
- document client-side filtering, sorting, and pagination
- add tests covering column filter behavior

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b8306915d8832ab37b09720a4a5c22