### PR TITLE
ci: migrate production and preview databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,32 @@ jobs:
         fi
         echo "✅ No high or critical vulnerabilities found"
 
+  migrate:
+    name: Run Migrations
+    runs-on: ubuntu-latest
+    needs: [test, security-scan]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run database migrations
+      env:
+        DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.MIGRATION_DATABASE_URL || secrets.PREVIEW_MIGRATION_DATABASE_URL }}
+      run: npm run db:migrate
+
   notify:
     name: Notification
     runs-on: ubuntu-latest
-    needs: [test, security-scan]
+    needs: [test, security-scan, migrate]
     if: always()
 
     steps:

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,3 +9,10 @@
 ## Pagination and Sorting
 - TanStack Table's client-side pagination and sorting are retained.
 - Filters operate in conjunction with pagination and sorting.
+
+## CI Database Migrations
+- After tests and security scans succeed, a `migrate` job runs.
+- The job selects the database URL based on the branch:
+  - `main` uses `MIGRATION_DATABASE_URL` for production.
+  - Other branches use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
+- `npm run db:migrate` applies the latest migrations to the selected database.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,3 +5,6 @@
 - Provide "全選択" (check all) and "全解除" (uncheck all) controls for each column filter.
 - Filters are rendered above the table for quick access.
 - Filtering, sorting, and pagination operate entirely on the client without server calls.
+- CI automatically runs database migrations:
+  - Pushes to `main` use `MIGRATION_DATABASE_URL` for production.
+  - Other branches and pull requests use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.


### PR DESCRIPTION
## Summary
- migrate production DB on main with `MIGRATION_DATABASE_URL`
- migrate preview DB on other branches with `PREVIEW_MIGRATION_DATABASE_URL`
- document automatic migrations in requirements and design docs

## Testing
- `USE_LOCAL_DB=true npm run lint`
- `USE_LOCAL_DB=true npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b8454808f4832aa4e82bc09b67b68e