### PR TITLE
Consolidate CI steps into single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  test:
-    name: Test and Build
+  ci:
+    name: Test, Scan, Build, Migrate
     runs-on: ubuntu-latest
 
     services:
@@ -85,24 +85,6 @@ jobs:
         fi
         echo "✅ Build completed successfully"
 
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-
-    - name: Install dependencies
-      run: npm ci
-
     - name: Run security audit
       run: npm audit --omit=dev --audit-level=moderate
 
@@ -112,7 +94,7 @@ jobs:
         if [ -s audit-results.json ]; then
           HIGH_VULNS=$(cat audit-results.json | jq '.metadata.vulnerabilities.high // 0')
           CRITICAL_VULNS=$(cat audit-results.json | jq '.metadata.vulnerabilities.critical // 0')
-          
+
           if [ "$HIGH_VULNS" -gt 0 ] || [ "$CRITICAL_VULNS" -gt 0 ]; then
             echo "⚠️ High or critical vulnerabilities found:"
             echo "High: $HIGH_VULNS, Critical: $CRITICAL_VULNS"
@@ -122,24 +104,7 @@ jobs:
         fi
         echo "✅ No high or critical vulnerabilities found"
 
-  migrate:
-    name: Run Migrations
-    runs-on: ubuntu-latest
-    needs: [test, security-scan]
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Run database migrations
+    - name: Run production or preview migrations
       env:
         DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.MIGRATION_DATABASE_URL || secrets.PREVIEW_MIGRATION_DATABASE_URL }}
       run: npm run db:migrate
@@ -147,12 +112,12 @@ jobs:
   notify:
     name: Notification
     runs-on: ubuntu-latest
-    needs: [test, security-scan, migrate]
+    needs: ci
     if: always()
 
     steps:
     - name: Notify success
-      if: needs.test.result == 'success' && needs.security-scan.result == 'success'
+      if: needs.ci.result == 'success'
       run: |
         echo "✅ All checks passed successfully!"
         echo "- Tests: ✅"
@@ -160,9 +125,9 @@ jobs:
         echo "- Build: ✅"
 
     - name: Notify failure
-      if: needs.test.result == 'failure' || needs.security-scan.result == 'failure'
+      if: needs.ci.result != 'success'
       run: |
         echo "❌ Some checks failed:"
-        echo "- Tests: ${{ needs.test.result }}"
-        echo "- Security: ${{ needs.security-scan.result }}"
+        echo "- CI result: ${{ needs.ci.result }}"
         exit 1
+

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,9 +10,10 @@
 - TanStack Table's client-side pagination and sorting are retained.
 - Filters operate in conjunction with pagination and sorting.
 
-## CI Database Migrations
-- After tests and security scans succeed, a `migrate` job runs.
-- The job selects the database URL based on the branch:
+## CI Pipeline
+- A single job handles linting, type checking, tests, security scan, build, and database migrations.
+- Migrations select the database URL based on the branch:
   - `main` uses `MIGRATION_DATABASE_URL` for production.
   - Other branches use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
-- `npm run db:migrate` applies the latest migrations to the selected database.
+- `npm run db:migrate` applies the latest migrations to the selected database after tests and security checks pass.
+- Tests run against an in-memory database (`USE_LOCAL_DB=true`) to keep CI isolated from PostgreSQL while migrations target the appropriate environment.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -8,3 +8,5 @@
 - CI automatically runs database migrations:
   - Pushes to `main` use `MIGRATION_DATABASE_URL` for production.
   - Other branches and pull requests use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
+- The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
+- Tests execute against an in-memory database (`USE_LOCAL_DB=true`) while migrations target the appropriate branch-specific database URLs.


### PR DESCRIPTION
## Summary
- run tests, security scan, build, and migrations in a single CI job without repeated installs
- document that tests use an in-memory database while migrations use branch-specific URLs
- fix workflow indentation so security audit and migration steps execute separately

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b852de00b0832a835f91f813b9d5cf