### PR TITLE
refactor user type to expose apps and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Next.js + TypeScript + PostgreSQL で構築されたシンプルなTODOリスト
 - ✅ 表右上のページサイズセレクター（3/10/30件、デフォルト30件）
 - ✅ フィルタ・ソート・ページネーション状態は URL クエリに保持され、新規作成後も維持
 - ✅ `useSearchParams` を利用するページは Next.js の仕様に従い `<Suspense>` でラップ
-- ✅ ユーザー、利用アプリ、ロールを管理するテーブル
+- ✅ ユーザー、利用アプリ、ロールを管理するテーブル (`User & { Apps: string[]; AppRoles: AppRole[] }`)
 
 ## セットアップ
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -17,6 +17,7 @@
 - `users` stores basic account details (name, email, timestamps).
 - `user_apps` links each user to accessible applications.
 - `user_roles` records role names associated with a user.
+- User records are exposed as `User & { Apps: string[]; AppRoles: AppRole[] }` on the API.
 
 ## CI Pipeline
 - A single job handles linting, type checking, tests, security scan, build, and database migrations.
@@ -25,3 +26,4 @@
   - Other branches use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
   - `npm run db:migrate` applies the latest migrations with `drizzle-kit migrate` to the selected database.
   - Tests run against an in-memory database (`USE_LOCAL_DB=true`) to keep CI isolated from PostgreSQL while migrations target the appropriate environment.
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -13,4 +13,5 @@
   - Other branches and pull requests use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
 - The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
 - Tests execute against an in-memory database (`USE_LOCAL_DB=true`) while migrations target the appropriate branch-specific database URLs.
-- User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.
+- User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables, returning `User & { Apps: string[]; AppRoles: AppRole[] }` objects.
+

--- a/src/app/users/edit/[id]/page.tsx
+++ b/src/app/users/edit/[id]/page.tsx
@@ -47,15 +47,15 @@ export default function EditUserPage({ params }: EditUserPageProps) {
   }
 
   return (
-    <UserForm 
-      mode="edit" 
+    <UserForm
+      mode="edit"
       initialData={{
-        id: user.userid,
-        name: user.username,
+        id: user.id,
+        name: user.name,
         email: user.email,
-        apps: user.apps,
-        roles: user.roles,
-      }} 
+        apps: user.Apps,
+        roles: user.AppRoles,
+      }}
     />
   );
 }

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -35,10 +35,10 @@ export function UserTable() {
 
   return (
     <div className="container mx-auto py-10">
-      <DataTable 
-        columns={columns} 
-        data={users} 
-        searchKey="username"
+      <DataTable
+        columns={columns}
+        data={users}
+        searchKey="name"
         searchPlaceholder="Search users..."
       />
     </div>

--- a/src/components/users/columns.tsx
+++ b/src/components/users/columns.tsx
@@ -33,7 +33,7 @@ export const columns: ColumnDef<UserWithAppsAndRoles>[] = [
     enableHiding: false,
   },
   {
-    accessorKey: "userid",
+    accessorKey: "id",
     header: ({ column }) => {
       return (
         <Button
@@ -45,10 +45,10 @@ export const columns: ColumnDef<UserWithAppsAndRoles>[] = [
         </Button>
       )
     },
-    cell: ({ row }) => <div className="font-medium">{row.getValue("userid")}</div>,
+    cell: ({ row }) => <div className="font-medium">{row.getValue("id")}</div>,
   },
   {
-    accessorKey: "username",
+    accessorKey: "name",
     header: ({ column }) => {
       return (
         <Button
@@ -60,13 +60,13 @@ export const columns: ColumnDef<UserWithAppsAndRoles>[] = [
         </Button>
       )
     },
-    cell: ({ row }) => <div className="lowercase">{row.getValue("username")}</div>,
+    cell: ({ row }) => <div className="lowercase">{row.getValue("name")}</div>,
   },
   {
-    accessorKey: "apps",
+    accessorKey: "Apps",
     header: "Apps",
     cell: ({ row }) => {
-      const apps = row.getValue("apps") as string[]
+      const apps = row.getValue("Apps") as string[]
       return (
         <div className="flex flex-wrap gap-1">
           {apps.map((app, index) => (
@@ -82,10 +82,10 @@ export const columns: ColumnDef<UserWithAppsAndRoles>[] = [
     },
   },
   {
-    accessorKey: "roles",
+    accessorKey: "AppRoles",
     header: "Roles",
     cell: ({ row }) => {
-      const roles = row.getValue("roles") as string[]
+      const roles = row.getValue("AppRoles") as string[]
       return (
         <div className="flex flex-wrap gap-1">
           {roles.map((role, index) => (
@@ -122,13 +122,13 @@ function UserActions({ user }: { user: UserWithAppsAndRoles }) {
   })
 
   const handleEdit = () => {
-    router.push(`/users/edit/${user.userid}`)
+    router.push(`/users/edit/${user.id}`)
   }
 
   const handleDelete = async () => {
     if (window.confirm("Are you sure you want to delete this user?")) {
       try {
-        await deleteMutation.mutateAsync({ id: user.userid })
+        await deleteMutation.mutateAsync({ id: user.id })
       } catch (error) {
         console.error("Error deleting user:", error)
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,9 @@
-export type UserWithAppsAndRoles = {
-  userid: number;
-  username: string;
-  email: string;
-  apps: string[];
-  roles: string[];
+import type { User } from '@/server/db/schema';
+import type { AppRole } from './apps-config';
+
+export type UserWithAppsAndRoles = Omit<User, 'created_at' | 'updated_at'> & {
+  created_at: string;
+  updated_at: string;
+  Apps: string[];
+  AppRoles: AppRole[];
 };

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -86,11 +86,6 @@ export type User = typeof users.$inferSelect;
 export type UserApp = typeof userApps.$inferSelect;
 export type UserRole = typeof userRoles.$inferSelect;
 
-export type UserWithAppsAndRoles = User & {
-  apps: UserApp[];
-  roles: UserRole[];
-};
-
 // Serialized types for tRPC (Date -> string)
 export type TodoSerialized = Omit<Todo, 'created_at' | 'updated_at' | 'deleted_at'> & {
   created_at: string;

--- a/src/server/services/userService.ts
+++ b/src/server/services/userService.ts
@@ -1,29 +1,13 @@
 import { userRepository } from '@/server/repositories/userRepository';
-import type { UserWithAppsAndRoles as ClientUserType } from '@/lib/types';
+import type { UserWithAppsAndRoles } from '@/lib/types';
 
 export const userService = {
-  getAll: async (): Promise<ClientUserType[]> => {
-    const users = await userRepository.getAll();
-    return users.map(user => ({
-      userid: user.id,
-      username: user.name,
-      email: user.email,
-      apps: user.apps.map(app => app.app_name),
-      roles: user.roles.map(role => `${role.app_name}-${role.role}`),
-    }));
+  getAll: async (): Promise<UserWithAppsAndRoles[]> => {
+    return await userRepository.getAll();
   },
 
-  getById: async (id: number): Promise<ClientUserType | null> => {
-    const user = await userRepository.getById(id);
-    if (!user) return null;
-    
-    return {
-      userid: user.id,
-      username: user.name,
-      email: user.email,
-      apps: user.apps.map(app => app.app_name),
-      roles: user.roles.map(role => `${role.app_name}-${role.role}`),
-    };
+  getById: async (id: number): Promise<UserWithAppsAndRoles | null> => {
+    return await userRepository.getById(id);
   },
 
   create: async (input: { name: string; email: string; apps: string[]; appRoles: { app_name: string; role: string }[] }) => {


### PR DESCRIPTION
## Summary
- expose user `Apps` and `AppRoles` fields
- simplify user service to return repository data
- document new user shape in requirements, design, and README

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c414f2b068832aae6f71271c00a33b