### PR TITLE
feat: add 30 rows of dummy user data and page size selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^4.36.1",
@@ -1915,6 +1916,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1958,6 +1965,32 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2036,6 +2069,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2288,6 +2336,49 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
@@ -2461,6 +2552,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^4.36.1",

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -18,6 +18,13 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
   Table,
   TableBody,
   TableCell,
@@ -129,28 +136,57 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <div className="flex-1 text-sm text-muted-foreground">
-          {table.getFilteredSelectedRowModel().rows.length} of{" "}
-          {table.getFilteredRowModel().rows.length} row(s) selected.
+      <div className="flex items-center justify-between space-x-2 py-4">
+        <div className="flex items-center space-x-2">
+          <p className="text-sm font-medium">Rows per page</p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => {
+              table.setPageSize(Number(value))
+            }}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {[10, 100, 1000].map((pageSize) => (
+                <SelectItem key={pageSize} value={`${pageSize}`}>
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-        <div className="space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            Next
-          </Button>
+        
+        <div className="flex items-center space-x-6 lg:space-x-8">
+          <div className="flex items-center space-x-2">
+            <p className="text-sm font-medium">
+              Page {table.getState().pagination.pageIndex + 1} of{" "}
+              {table.getPageCount()}
+            </p>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {table.getFilteredSelectedRowModel().rows.length} of{" "}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Next
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/server/repositories/userRepository.ts
+++ b/src/server/repositories/userRepository.ts
@@ -144,44 +144,40 @@ class PgUserRepository implements UserRepository {
 
 class MemoryUserRepository implements UserRepository {
   private users: User[] = [
-    {
-      id: 1,
-      name: 'john_doe',
-      email: 'john@example.com',
-      created_at: new Date('2024-01-01'),
-      updated_at: new Date('2024-01-01'),
-    },
-    {
-      id: 2,
-      name: 'jane_smith',
-      email: 'jane@example.com',
-      created_at: new Date('2024-01-02'),
-      updated_at: new Date('2024-01-02'),
-    },
-    {
-      id: 3,
-      name: 'bob_wilson',
-      email: 'bob@example.com',
-      created_at: new Date('2024-01-03'),
-      updated_at: new Date('2024-01-03'),
-    },
-    {
-      id: 4,
-      name: 'alice_brown',
-      email: 'alice@example.com',
-      created_at: new Date('2024-01-04'),
-      updated_at: new Date('2024-01-04'),
-    },
-    {
-      id: 5,
-      name: 'charlie_davis',
-      email: 'charlie@example.com',
-      created_at: new Date('2024-01-05'),
-      updated_at: new Date('2024-01-05'),
-    },
+    { id: 1, name: 'john_doe', email: 'john@example.com', created_at: new Date('2024-01-01'), updated_at: new Date('2024-01-01') },
+    { id: 2, name: 'jane_smith', email: 'jane@example.com', created_at: new Date('2024-01-02'), updated_at: new Date('2024-01-02') },
+    { id: 3, name: 'bob_wilson', email: 'bob@example.com', created_at: new Date('2024-01-03'), updated_at: new Date('2024-01-03') },
+    { id: 4, name: 'alice_brown', email: 'alice@example.com', created_at: new Date('2024-01-04'), updated_at: new Date('2024-01-04') },
+    { id: 5, name: 'charlie_davis', email: 'charlie@example.com', created_at: new Date('2024-01-05'), updated_at: new Date('2024-01-05') },
+    { id: 6, name: 'emma_johnson', email: 'emma@example.com', created_at: new Date('2024-01-06'), updated_at: new Date('2024-01-06') },
+    { id: 7, name: 'david_miller', email: 'david@example.com', created_at: new Date('2024-01-07'), updated_at: new Date('2024-01-07') },
+    { id: 8, name: 'sarah_garcia', email: 'sarah@example.com', created_at: new Date('2024-01-08'), updated_at: new Date('2024-01-08') },
+    { id: 9, name: 'michael_rodriguez', email: 'michael@example.com', created_at: new Date('2024-01-09'), updated_at: new Date('2024-01-09') },
+    { id: 10, name: 'lisa_martinez', email: 'lisa@example.com', created_at: new Date('2024-01-10'), updated_at: new Date('2024-01-10') },
+    { id: 11, name: 'kevin_anderson', email: 'kevin@example.com', created_at: new Date('2024-01-11'), updated_at: new Date('2024-01-11') },
+    { id: 12, name: 'maria_taylor', email: 'maria@example.com', created_at: new Date('2024-01-12'), updated_at: new Date('2024-01-12') },
+    { id: 13, name: 'james_thomas', email: 'james@example.com', created_at: new Date('2024-01-13'), updated_at: new Date('2024-01-13') },
+    { id: 14, name: 'jennifer_jackson', email: 'jennifer@example.com', created_at: new Date('2024-01-14'), updated_at: new Date('2024-01-14') },
+    { id: 15, name: 'robert_white', email: 'robert@example.com', created_at: new Date('2024-01-15'), updated_at: new Date('2024-01-15') },
+    { id: 16, name: 'linda_harris', email: 'linda@example.com', created_at: new Date('2024-01-16'), updated_at: new Date('2024-01-16') },
+    { id: 17, name: 'william_clark', email: 'william@example.com', created_at: new Date('2024-01-17'), updated_at: new Date('2024-01-17') },
+    { id: 18, name: 'patricia_lewis', email: 'patricia@example.com', created_at: new Date('2024-01-18'), updated_at: new Date('2024-01-18') },
+    { id: 19, name: 'daniel_walker', email: 'daniel@example.com', created_at: new Date('2024-01-19'), updated_at: new Date('2024-01-19') },
+    { id: 20, name: 'nancy_hall', email: 'nancy@example.com', created_at: new Date('2024-01-20'), updated_at: new Date('2024-01-20') },
+    { id: 21, name: 'mark_allen', email: 'mark@example.com', created_at: new Date('2024-01-21'), updated_at: new Date('2024-01-21') },
+    { id: 22, name: 'helen_young', email: 'helen@example.com', created_at: new Date('2024-01-22'), updated_at: new Date('2024-01-22') },
+    { id: 23, name: 'paul_hernandez', email: 'paul@example.com', created_at: new Date('2024-01-23'), updated_at: new Date('2024-01-23') },
+    { id: 24, name: 'susan_king', email: 'susan@example.com', created_at: new Date('2024-01-24'), updated_at: new Date('2024-01-24') },
+    { id: 25, name: 'andrew_wright', email: 'andrew@example.com', created_at: new Date('2024-01-25'), updated_at: new Date('2024-01-25') },
+    { id: 26, name: 'donna_lopez', email: 'donna@example.com', created_at: new Date('2024-01-26'), updated_at: new Date('2024-01-26') },
+    { id: 27, name: 'steven_hill', email: 'steven@example.com', created_at: new Date('2024-01-27'), updated_at: new Date('2024-01-27') },
+    { id: 28, name: 'ruth_scott', email: 'ruth@example.com', created_at: new Date('2024-01-28'), updated_at: new Date('2024-01-28') },
+    { id: 29, name: 'anthony_green', email: 'anthony@example.com', created_at: new Date('2024-01-29'), updated_at: new Date('2024-01-29') },
+    { id: 30, name: 'carol_adams', email: 'carol@example.com', created_at: new Date('2024-01-30'), updated_at: new Date('2024-01-30') },
   ];
 
   private userApps: UserApp[] = [
+    // Users 1-10: Mixed access patterns
     { id: 1, user_id: 1, app_name: 'usermanager', created_at: new Date() },
     { id: 2, user_id: 1, app_name: 'quoteapp', created_at: new Date() },
     { id: 3, user_id: 2, app_name: 'quoteapp', created_at: new Date() },
@@ -189,9 +185,44 @@ class MemoryUserRepository implements UserRepository {
     { id: 5, user_id: 4, app_name: 'usermanager', created_at: new Date() },
     { id: 6, user_id: 4, app_name: 'quoteapp', created_at: new Date() },
     { id: 7, user_id: 5, app_name: 'quoteapp', created_at: new Date() },
+    { id: 8, user_id: 6, app_name: 'usermanager', created_at: new Date() },
+    { id: 9, user_id: 7, app_name: 'usermanager', created_at: new Date() },
+    { id: 10, user_id: 7, app_name: 'quoteapp', created_at: new Date() },
+    { id: 11, user_id: 8, app_name: 'quoteapp', created_at: new Date() },
+    { id: 12, user_id: 9, app_name: 'usermanager', created_at: new Date() },
+    { id: 13, user_id: 10, app_name: 'quoteapp', created_at: new Date() },
+    // Users 11-20: More patterns
+    { id: 14, user_id: 11, app_name: 'usermanager', created_at: new Date() },
+    { id: 15, user_id: 11, app_name: 'quoteapp', created_at: new Date() },
+    { id: 16, user_id: 12, app_name: 'usermanager', created_at: new Date() },
+    { id: 17, user_id: 13, app_name: 'quoteapp', created_at: new Date() },
+    { id: 18, user_id: 14, app_name: 'usermanager', created_at: new Date() },
+    { id: 19, user_id: 15, app_name: 'quoteapp', created_at: new Date() },
+    { id: 20, user_id: 16, app_name: 'usermanager', created_at: new Date() },
+    { id: 21, user_id: 16, app_name: 'quoteapp', created_at: new Date() },
+    { id: 22, user_id: 17, app_name: 'usermanager', created_at: new Date() },
+    { id: 23, user_id: 18, app_name: 'quoteapp', created_at: new Date() },
+    { id: 24, user_id: 19, app_name: 'usermanager', created_at: new Date() },
+    { id: 25, user_id: 20, app_name: 'quoteapp', created_at: new Date() },
+    // Users 21-30: Additional patterns
+    { id: 26, user_id: 21, app_name: 'usermanager', created_at: new Date() },
+    { id: 27, user_id: 21, app_name: 'quoteapp', created_at: new Date() },
+    { id: 28, user_id: 22, app_name: 'usermanager', created_at: new Date() },
+    { id: 29, user_id: 23, app_name: 'quoteapp', created_at: new Date() },
+    { id: 30, user_id: 24, app_name: 'usermanager', created_at: new Date() },
+    { id: 31, user_id: 24, app_name: 'quoteapp', created_at: new Date() },
+    { id: 32, user_id: 25, app_name: 'usermanager', created_at: new Date() },
+    { id: 33, user_id: 26, app_name: 'quoteapp', created_at: new Date() },
+    { id: 34, user_id: 27, app_name: 'usermanager', created_at: new Date() },
+    { id: 35, user_id: 27, app_name: 'quoteapp', created_at: new Date() },
+    { id: 36, user_id: 28, app_name: 'quoteapp', created_at: new Date() },
+    { id: 37, user_id: 29, app_name: 'usermanager', created_at: new Date() },
+    { id: 38, user_id: 30, app_name: 'usermanager', created_at: new Date() },
+    { id: 39, user_id: 30, app_name: 'quoteapp', created_at: new Date() },
   ];
 
   private userRoles: UserRole[] = [
+    // Users 1-10: Mixed role patterns
     { id: 1, user_id: 1, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
     { id: 2, user_id: 1, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
     { id: 3, user_id: 2, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
@@ -199,11 +230,45 @@ class MemoryUserRepository implements UserRepository {
     { id: 5, user_id: 4, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
     { id: 6, user_id: 4, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
     { id: 7, user_id: 5, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 8, user_id: 6, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 9, user_id: 7, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 10, user_id: 7, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 11, user_id: 8, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 12, user_id: 9, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 13, user_id: 10, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    // Users 11-20: Additional role assignments
+    { id: 14, user_id: 11, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 15, user_id: 11, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 16, user_id: 12, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 17, user_id: 13, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 18, user_id: 14, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 19, user_id: 15, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 20, user_id: 16, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 21, user_id: 16, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 22, user_id: 17, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 23, user_id: 18, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 24, user_id: 19, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 25, user_id: 20, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    // Users 21-30: Final role assignments
+    { id: 26, user_id: 21, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 27, user_id: 21, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 28, user_id: 22, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 29, user_id: 23, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 30, user_id: 24, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 31, user_id: 24, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 32, user_id: 25, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 33, user_id: 26, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 34, user_id: 27, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 35, user_id: 27, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
+    { id: 36, user_id: 28, app_name: 'quoteapp', role: 'quoteapp-trader', created_at: new Date() },
+    { id: 37, user_id: 29, app_name: 'usermanager', role: 'usermanager-approver', created_at: new Date() },
+    { id: 38, user_id: 30, app_name: 'usermanager', role: 'usermanager-admin', created_at: new Date() },
+    { id: 39, user_id: 30, app_name: 'quoteapp', role: 'quoteapp-sales', created_at: new Date() },
   ];
 
-  private nextUserId = 6;
-  private nextUserAppId = 8;
-  private nextUserRoleId = 8;
+  private nextUserId = 31;
+  private nextUserAppId = 40;
+  private nextUserRoleId = 40;
 
   async getAll(): Promise<UserWithAppsAndRoles[]> {
     return this.users.map(user => ({


### PR DESCRIPTION
- Expand dummy data to 30 users with varied names and email addresses
- Add comprehensive user app assignments (usermanager, quoteapp)
- Include diverse role assignments (admin, approver, sales, trader)
- Add shadcn/ui Select component for page size selection
- Implement page size selector with options: 10, 100, 1000
- Enhance pagination UI with page counter and better spacing
- Update repository counters for proper ID generation

Features:
- 30 realistic user records with unique names and emails
- Mixed app and role assignments for better filtering testing
- Professional pagination controls with selectable page sizes
- Improved table navigation with page information display

🤖 Generated with [Claude Code](https://claude.ai/code)