### PR TITLE
Add service and repository tests with coverage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,20 @@ npm run dev
 - `npm run start` - プロダクションサーバーの起動
 - `npm run lint` - ESLintによるコードチェック
 - `npm run test` - Vitestによるテスト実行
+- `npm run test:coverage` - カバレッジ付きでテストを実行
 - `npm run db:generate` - Drizzleマイグレーションファイル生成
 - `npm run db:migrate` - Drizzleマイグレーションファイルを適用 (`drizzle-kit migrate`)
 - `npm run db:studio` - Drizzle Studioの起動
 - `npm run db:drop` - データベーステーブルの削除
+
+## テスト
+
+テストはインメモリデータベースで実行します。
+
+```bash
+USE_LOCAL_DB=true npm test -- --run
+USE_LOCAL_DB=true npm run test:coverage -- --run
+```
 
 ## データベース管理
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -25,3 +25,8 @@
   - Other branches use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
   - `npm run db:migrate` applies the latest migrations with `drizzle-kit migrate` to the selected database.
   - Tests run against an in-memory database (`USE_LOCAL_DB=true`) to keep CI isolated from PostgreSQL while migrations target the appropriate environment.
+
+## Testing
+- Unit tests verify components, services, and repositories.
+- Integration tests exercise the todo service with the in-memory repository.
+- Run `npm run test:coverage` to inspect coverage.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -13,4 +13,6 @@
   - Other branches and pull requests use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
 - The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
 - Tests execute against an in-memory database (`USE_LOCAL_DB=true`) while migrations target the appropriate branch-specific database URLs.
+- Unit tests cover components, services, and repositories, and integration tests verify service and repository interaction.
+- Run `npm run test:coverage` to check test coverage.
 - User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.

--- a/src/__tests__/integration/todoServiceRepository.test.ts
+++ b/src/__tests__/integration/todoServiceRepository.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { TodoService } from '@/server/services/todoService';
+
+let service: TodoService;
+
+describe('todoService with memory repository', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv('USE_LOCAL_DB', 'true');
+    ({ todoService: service } = await import('@/server/services/todoService'));
+  });
+
+  it('creates and fetches todos', async () => {
+    const created = await service.create({ title: 'Integration', due_date: null });
+    const all = await service.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe(created.id);
+  });
+
+  it('toggles todo status', async () => {
+    const created = await service.create({ title: 'Toggle', due_date: null });
+    await service.toggle(created.id);
+    const all = await service.getAll();
+    expect(all[0].done_flag).toBe(true);
+  });
+});

--- a/src/__tests__/server/todoRepository.test.ts
+++ b/src/__tests__/server/todoRepository.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { TodoRepository } from '@/server/repositories/todoRepository';
+
+let repo: TodoRepository;
+
+describe('MemoryTodoRepository', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv('USE_LOCAL_DB', 'true');
+    ({ todoRepository: repo } = await import('@/server/repositories/todoRepository'));
+  });
+
+  it('creates and retrieves todos', async () => {
+    await repo.create({ title: 'Test', due_date: null });
+    const all = await repo.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].title).toBe('Test');
+    expect(all[0].auditLogs).toHaveLength(1);
+  });
+
+  it('updates todo', async () => {
+    const created = await repo.create({ title: 'Old', due_date: null });
+    const updated = await repo.update({ id: created.id, title: 'New' });
+    expect(updated.title).toBe('New');
+  });
+
+  it('deletes todo', async () => {
+    const created = await repo.create({ title: 'Delete', due_date: null });
+    await repo.delete(created.id);
+    const all = await repo.getAll();
+    expect(all).toHaveLength(0);
+  });
+
+  it('toggles done flag', async () => {
+    const created = await repo.create({ title: 'Toggle', due_date: null });
+    const toggled = await repo.toggle(created.id);
+    expect(toggled.done_flag).toBe(true);
+  });
+});

--- a/src/__tests__/server/todoService.test.ts
+++ b/src/__tests__/server/todoService.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { todoService } from '@/server/services/todoService';
+import { todoRepository } from '@/server/repositories/todoRepository';
+
+vi.mock('@/server/repositories/todoRepository', () => ({
+  todoRepository: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    toggle: vi.fn(),
+  },
+}));
+
+describe('todoService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates getAll to repository', async () => {
+    (todoRepository.getAll as any).mockResolvedValue([{ id: 1 }]);
+    const result = await todoService.getAll();
+    expect(todoRepository.getAll).toHaveBeenCalled();
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it('delegates create to repository', async () => {
+    const input = { title: 'Test', due_date: null };
+    const created = { id: 1, ...input, done_flag: false };
+    (todoRepository.create as any).mockResolvedValue(created);
+    const result = await todoService.create(input);
+    expect(todoRepository.create).toHaveBeenCalledWith(input);
+    expect(result).toEqual(created);
+  });
+
+  it('delegates update to repository', async () => {
+    const input = { id: 1, title: 'Updated', due_date: null };
+    (todoRepository.update as any).mockResolvedValue(input);
+    const result = await todoService.update(input);
+    expect(todoRepository.update).toHaveBeenCalledWith(input);
+    expect(result).toEqual(input);
+  });
+
+  it('delegates delete to repository', async () => {
+    (todoRepository.delete as any).mockResolvedValue({ success: true });
+    const result = await todoService.delete(1);
+    expect(todoRepository.delete).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ success: true });
+  });
+
+  it('delegates toggle to repository', async () => {
+    const toggled = { id: 1, done_flag: true };
+    (todoRepository.toggle as any).mockResolvedValue(toggled);
+    const result = await todoService.toggle(1);
+    expect(todoRepository.toggle).toHaveBeenCalledWith(1);
+    expect(result).toEqual(toggled);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for todo service and repository
- add integration test exercising service with in-memory repository
- document test and coverage execution

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `USE_LOCAL_DB=true npm test -- --run`
- `USE_LOCAL_DB=true npm run test:coverage -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c4b9dd5ed0832ab88033be9201834d