### PR TITLE
Use embedded PostgreSQL (PGlite) for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ npm run dev
 
 ## テスト
 
-テストはインメモリデータベースで実行します。
+テストは組み込みのPostgreSQL互換エンジン[PGlite](https://github.com/electric-sql/pglite)上で実行します。
+旧来のインメモリリポジトリを利用したい場合は `USE_LOCAL_DB=true` を指定してください。
 
 ```bash
-USE_LOCAL_DB=true npm test -- --run
-USE_LOCAL_DB=true npm run test:coverage -- --run
+npm test -- --run
+npm run test:coverage -- --run
 ```
 
 ## データベース管理

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,9 +24,9 @@
   - `main` uses `MIGRATION_DATABASE_URL` for production.
   - Other branches use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
   - `npm run db:migrate` applies the latest migrations with `drizzle-kit migrate` to the selected database.
-  - Tests run against an in-memory database (`USE_LOCAL_DB=true`) to keep CI isolated from PostgreSQL while migrations target the appropriate environment.
+  - Tests run against an embedded PostgreSQL engine (PGlite) to keep CI isolated from external databases; set `USE_LOCAL_DB=true` to use the in-memory repository if needed.
 
 ## Testing
 - Unit tests verify components, services, and repositories.
-- Integration tests exercise the todo service with the in-memory repository.
+- Integration tests exercise the todo service with the PostgreSQL-backed repository.
 - Run `npm run test:coverage` to inspect coverage.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -12,7 +12,7 @@
   - Pushes to `main` use `MIGRATION_DATABASE_URL` for production.
   - Other branches and pull requests use `PREVIEW_MIGRATION_DATABASE_URL` for preview environments.
 - The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
-- Tests execute against an in-memory database (`USE_LOCAL_DB=true`) while migrations target the appropriate branch-specific database URLs.
+- Tests execute against an embedded PostgreSQL database (PGlite). Setting `USE_LOCAL_DB=true` switches to a simplified in-memory repository.
 - Unit tests cover components, services, and repositories, and integration tests verify service and repository interaction.
 - Run `npm run test:coverage` to check test coverage.
 - User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.3.8",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^20.16.1",
@@ -534,6 +535,13 @@
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.8.tgz",
+      "integrity": "sha512-VlAz/R7mktifp9IHzNvjxWJM8p3fPH2lHpustYuRSOXOpXiAMTlA5qqxcufPaDnfee6CZCE9qrT1MHDT7riSHg==",
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.3.8",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^20.16.1",

--- a/src/__tests__/integration/todoServiceRepository.test.ts
+++ b/src/__tests__/integration/todoServiceRepository.test.ts
@@ -1,13 +1,50 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import * as schema from '@/server/db/schema';
 import type { TodoService } from '@/server/services/todoService';
 
 let service: TodoService;
+let pg: PGlite;
+let db: ReturnType<typeof drizzle>;
 
-describe('todoService with memory repository', () => {
+describe('todoService with Pg repository', () => {
+  beforeAll(async () => {
+    pg = new PGlite();
+    db = drizzle(pg, { schema });
+    await pg.exec(`
+      CREATE TABLE IF NOT EXISTS "todos" (
+        id serial PRIMARY KEY,
+        title text NOT NULL,
+        due_date date,
+        done_flag boolean DEFAULT false NOT NULL,
+        created_at timestamp DEFAULT now() NOT NULL,
+        updated_at timestamp DEFAULT now() NOT NULL,
+        deleted_at timestamp
+      );
+    `);
+    await pg.exec(`
+      CREATE TABLE IF NOT EXISTS "audit_logs" (
+        id serial PRIMARY KEY,
+        todo_id integer NOT NULL REFERENCES todos(id),
+        action text NOT NULL,
+        old_values text,
+        new_values text,
+        created_at timestamp DEFAULT now() NOT NULL
+      );
+    `);
+  });
+
   beforeEach(async () => {
     vi.resetModules();
-    vi.stubEnv('USE_LOCAL_DB', 'true');
+    vi.doMock('@/server/db', () => ({ db }));
     ({ todoService: service } = await import('@/server/services/todoService'));
+    await db.delete(schema.auditLogs);
+    await db.delete(schema.todos);
+  });
+
+  afterAll(async () => {
+    await pg.close();
   });
 
   it('creates and fetches todos', async () => {


### PR DESCRIPTION
## Summary
- add PGlite dependency
- run repository/service tests against embedded PostgreSQL
- document PGlite-based testing setup

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c4be7f18fc832ab21e3750c5a3b653