### PR TITLE
test: run e2e against Vercel deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       run: |
         cat <<'EOF' > .env.local
         DATABASE_URL=postgresql://todo_user:todo_password@localhost:5432/todo_db
-        USE_LOCAL_DB=true
         EOF
 
     - name: Run database migrations
@@ -84,6 +83,29 @@ jobs:
           exit 1
         fi
         echo "✅ Build completed successfully"
+
+    - name: Set E2E base URL (production)
+      if: github.ref == 'refs/heads/main'
+      run: echo "E2E_BASE_URL=${{ secrets.VERCEL_PRODUCTION_URL }}" >> $GITHUB_ENV
+
+    - name: Fetch Vercel preview URL
+      if: github.ref != 'refs/heads/main'
+      env:
+        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      run: |
+        REPO_NAME=${GITHUB_REPOSITORY#*/}
+        BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}
+        API_URL="https://api.vercel.com/v13/deployments?project=$REPO_NAME&target=preview&meta-githubCommitRef=$BRANCH&limit=1"
+        DEPLOYMENT_URL=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" "$API_URL" | jq -r '.deployments[0].url')
+        echo "E2E_BASE_URL=https://$DEPLOYMENT_URL/" >> $GITHUB_ENV
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps
+
+    - name: Run e2e tests
+      env:
+        E2E_BASE_URL: ${{ env.E2E_BASE_URL }}
+      run: npm run test:e2e
 
     - name: Run security audit
       run: npm audit --omit=dev --audit-level=moderate

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm run dev
 テストは組み込みのPostgreSQL互換エンジン[PGlite](https://github.com/electric-sql/pglite)上で実行します。
 Playwright のブラウザが未インストールの場合は `npx playwright install --with-deps` を実行してください。
 
-デプロイ済み環境でE2Eテストを実行する場合は `E2E_BASE_URL` に対象URLを設定します。GitHub ActionsのCIではプルリクエストで `VERCEL_TOKEN` を使用して最新のVercelプレビューURLを取得し、`main` ブランチでは `VERCEL_PRODUCTION_URL` を利用します。
+デプロイ済み環境でE2Eテストを実行する場合は `E2E_BASE_URL` に対象URLを設定します。GitHub Actions の CI では機能ブランチのプルリクエストで `VERCEL_TOKEN` を使って最新の Vercel プレビュー URL を取得して E2E テストを実行し、`main` ブランチにマージされた後は `VERCEL_PRODUCTION_URL` を用いて本番環境に対してテストを行います。
 
 ## データベース管理
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npm run dev
 テストは組み込みのPostgreSQL互換エンジン[PGlite](https://github.com/electric-sql/pglite)上で実行します。
 Playwright のブラウザが未インストールの場合は `npx playwright install --with-deps` を実行してください。
 
+デプロイ済み環境でE2Eテストを実行する場合は `E2E_BASE_URL` に対象URLを設定します。GitHub ActionsのCIではプルリクエストで `VERCEL_TOKEN` を使用して最新のVercelプレビューURLを取得し、`main` ブランチでは `VERCEL_PRODUCTION_URL` を利用します。
+
 ## データベース管理
 
 ### マイグレーション
@@ -145,3 +147,8 @@ npm run db:studio
 ```env
 DATABASE_URL="postgresql://todo_user:todo_password@localhost:5432/todo_db"
 ```
+
+### GitHub Secrets
+
+- `VERCEL_TOKEN` - VercelのプレビューURL取得に使用
+- `VERCEL_PRODUCTION_URL` - 本番デプロイ先のURL（末尾に `/` を含む）

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,10 +31,11 @@
   - Tests run against an embedded PostgreSQL engine (PGlite) to keep CI isolated from external databases.
 - Run `npm run ci` locally before committing to ensure formatting, type checks, linting, and tests all pass.
 - Before pushing to a remote branch, fetch and merge the latest `origin/main` to prevent conflicts.
+- Feature branches fetch the latest Vercel preview deployment using `VERCEL_TOKEN`, and `main` uses `VERCEL_PRODUCTION_URL` so end-to-end tests run against deployed environments.
 
 ## Testing
 
 - Unit tests verify components, services, and repositories.
 - Integration tests exercise the todo service with the in-memory repository.
-- End-to-end tests use Playwright to confirm UI behavior; install browsers with `npx playwright install --with-deps` and run `USE_LOCAL_DB=true npm run test:e2e`.
+- End-to-end tests use Playwright to confirm UI behavior; install browsers with `npx playwright install --with-deps` and run `npm run test:e2e`. Set `E2E_BASE_URL` to point tests at a deployed instance instead of starting the dev server.
 - Run `npm run test:coverage` to inspect coverage.

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,7 +31,7 @@
   - Tests run against an embedded PostgreSQL engine (PGlite) to keep CI isolated from external databases.
 - Run `npm run ci` locally before committing to ensure formatting, type checks, linting, and tests all pass.
 - Before pushing to a remote branch, fetch and merge the latest `origin/main` to prevent conflicts.
-- Feature branches fetch the latest Vercel preview deployment using `VERCEL_TOKEN`, and `main` uses `VERCEL_PRODUCTION_URL` so end-to-end tests run against deployed environments.
+- Feature branches fetch the latest Vercel preview deployment using `VERCEL_TOKEN` and run end-to-end tests against that preview, while `main` uses `VERCEL_PRODUCTION_URL` after merges to test the production deployment.
 
 ## Testing
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -19,4 +19,4 @@
 - User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.
 - Run `npm run ci` before committing to format code and validate type checks, linting, and tests.
 - Fetch and merge `origin/main` before pushing a feature branch to keep it up to date.
-- CI retrieves the Vercel preview URL using `VERCEL_TOKEN` for feature branches and uses `VERCEL_PRODUCTION_URL` on `main` to run end-to-end tests against deployed environments.
+- CI retrieves the Vercel preview URL using `VERCEL_TOKEN` for feature branches and runs end-to-end tests against that preview. The `main` branch uses `VERCEL_PRODUCTION_URL` after merges to exercise the production deployment.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -14,8 +14,9 @@
 - The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
 - Tests execute against an embedded PostgreSQL database (PGlite).
 - Unit tests cover components, services, and repositories, and integration tests verify service and repository interaction.
-- End-to-end tests verify core UI flows with Playwright; install browsers with `npx playwright install --with-deps` and run `USE_LOCAL_DB=true npm run test:e2e`.
+- End-to-end tests verify core UI flows with Playwright; install browsers with `npx playwright install --with-deps` and run `npm run test:e2e` locally. Set `E2E_BASE_URL` to test against a deployed instance instead of starting a local server.
 - Run `npm run test:coverage` to check test coverage.
 - User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.
 - Run `npm run ci` before committing to format code and validate type checks, linting, and tests.
 - Fetch and merge `origin/main` before pushing a feature branch to keep it up to date.
+- CI retrieves the Vercel preview URL using `VERCEL_TOKEN` for feature branches and uses `VERCEL_PRODUCTION_URL` on `main` to run end-to-end tests against deployed environments.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
+
 export default defineConfig({
   testDir: './e2e',
-  webServer: {
-    command: 'npm run dev',
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-  },
+  ...(process.env.E2E_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: 'npm run dev',
+          port: 3000,
+          reuseExistingServer: !process.env.CI,
+        },
+      }),
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
   },
 });


### PR DESCRIPTION
## Summary
- allow Playwright to use E2E_BASE_URL and skip local server
- run e2e tests in CI against Vercel deployments
- document Vercel secrets and remote e2e testing
- install Playwright browsers only when needed and drop USE_LOCAL_DB from CI and docs

## Testing
- `npm run ci` *(fails: Playwright browser download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ce85efc4832a94c00f1882183b07