### PR TITLE
test: run e2e against Vercel deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       run: |
         cat <<'EOF' > .env.local
         DATABASE_URL=postgresql://todo_user:todo_password@localhost:5432/todo_db
-        USE_LOCAL_DB=true
         EOF
 
     - name: Run database migrations
@@ -84,6 +83,20 @@ jobs:
           exit 1
         fi
         echo "✅ Build completed successfully"
+
+    - name: Set E2E base URL (production)
+      if: github.ref == 'refs/heads/main'
+      run: echo "E2E_BASE_URL=${{ secrets.VERCEL_PRODUCTION_URL }}" >> $GITHUB_ENV
+
+    - name: Install Playwright browsers
+      if: github.ref == 'refs/heads/main'
+      run: npx playwright install --with-deps
+
+    - name: Run e2e tests
+      if: github.ref == 'refs/heads/main'
+      env:
+        E2E_BASE_URL: ${{ env.E2E_BASE_URL }}
+      run: npm run test:e2e
 
     - name: Run security audit
       run: npm audit --omit=dev --audit-level=moderate

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npm run dev
 テストは組み込みのPostgreSQL互換エンジン[PGlite](https://github.com/electric-sql/pglite)上で実行します。
 Playwright のブラウザが未インストールの場合は `npx playwright install --with-deps` を実行してください。
 
+デプロイ済み環境でE2Eテストを実行する場合は `E2E_BASE_URL` に対象URLを設定します。GitHub Actions の CI では `main` ブランチにマージされた後のみ `VERCEL_PRODUCTION_URL` を用いて本番環境に対して E2E テストを実行し、機能ブランチでは E2E テストをスキップします。
+
 ## データベース管理
 
 ### マイグレーション
@@ -145,3 +147,7 @@ npm run db:studio
 ```env
 DATABASE_URL="postgresql://todo_user:todo_password@localhost:5432/todo_db"
 ```
+
+### GitHub Secrets
+
+- `VERCEL_PRODUCTION_URL` - 本番デプロイ先のURL（末尾に `/` を含む）

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,10 +31,11 @@
   - Tests run against an embedded PostgreSQL engine (PGlite) to keep CI isolated from external databases.
 - Run `npm run ci` locally before committing to ensure formatting, type checks, linting, and tests all pass.
 - Before pushing to a remote branch, fetch and merge the latest `origin/main` to prevent conflicts.
+- End-to-end tests run only after merges to `main`, targeting the production deployment via `VERCEL_PRODUCTION_URL`; feature branches skip these tests.
 
 ## Testing
 
 - Unit tests verify components, services, and repositories.
 - Integration tests exercise the todo service with the in-memory repository.
-- End-to-end tests use Playwright to confirm UI behavior; install browsers with `npx playwright install --with-deps` and run `USE_LOCAL_DB=true npm run test:e2e`.
+- End-to-end tests use Playwright to confirm UI behavior; install browsers with `npx playwright install --with-deps` and run `npm run test:e2e`. Set `E2E_BASE_URL` to point tests at a deployed instance instead of starting the dev server.
 - Run `npm run test:coverage` to inspect coverage.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -14,8 +14,9 @@
 - The CI pipeline runs tests, security scanning, and migrations within a single job to avoid repeated dependency installs.
 - Tests execute against an embedded PostgreSQL database (PGlite).
 - Unit tests cover components, services, and repositories, and integration tests verify service and repository interaction.
-- End-to-end tests verify core UI flows with Playwright; install browsers with `npx playwright install --with-deps` and run `USE_LOCAL_DB=true npm run test:e2e`.
+- End-to-end tests verify core UI flows with Playwright; install browsers with `npx playwright install --with-deps` and run `npm run test:e2e` locally. Set `E2E_BASE_URL` to test against a deployed instance instead of starting a local server.
 - Run `npm run test:coverage` to check test coverage.
 - User management persists user accounts along with associated applications and roles in `users`, `user_apps`, and `user_roles` tables.
 - Run `npm run ci` before committing to format code and validate type checks, linting, and tests.
 - Fetch and merge `origin/main` before pushing a feature branch to keep it up to date.
+- CI runs end-to-end tests only after merges to `main`, targeting `VERCEL_PRODUCTION_URL`; feature branches skip end-to-end tests.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
+
 export default defineConfig({
   testDir: './e2e',
-  webServer: {
-    command: 'npm run dev',
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-  },
+  ...(process.env.E2E_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: 'npm run dev',
+          port: 3000,
+          reuseExistingServer: !process.env.CI,
+        },
+      }),
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
   },
 });


### PR DESCRIPTION
## Summary
- run Playwright E2E tests in CI only on `main` against `VERCEL_PRODUCTION_URL`
- install Playwright browsers only on `main` and drop Vercel preview URL fetching
- document that feature branches skip E2E tests and `VERCEL_PRODUCTION_URL` is the only required secret

## Testing
- `npm run ci` *(fails: page.goto net::ERR_ABORTED when running Playwright E2E test)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ce85efc4832a94c00f1882183b07